### PR TITLE
Fix landing page first section responsiveness

### DIFF
--- a/app/landingPage/ParallaxRing.tsx
+++ b/app/landingPage/ParallaxRing.tsx
@@ -13,13 +13,13 @@ if (typeof window !== 'undefined') {
 export default function ParallaxRing() {
   // 2. Create a ref to attach to the element we want to move
   const ringRef = useRef<HTMLDivElement>(null);
-  
-  // Define the maximum distance (in pixels) the ring should move up
-  const MAX_PARALLAX_Y_MOVEMENT = -400; 
 
   useEffect(() => {
     const ringElement = ringRef.current;
     if (!ringElement) return;
+    
+    // Define the maximum distance (in pixels) the ring should move up
+    const MAX_PARALLAX_Y_MOVEMENT = window.innerWidth <= 768 ? -200 : -400;
 
     // 3. Set up the GSAP animation linked to the scroll
     // We use .to() to animate from the current state (defined by CSS 'bottom: -150px') 
@@ -63,7 +63,7 @@ export default function ParallaxRing() {
         alt="Ultrahuman Ring AIR"
         width={433}
         height={394}
-        sizes="(max-width: 768px) 30vw, (max-width: 480px) 35vw, 25vw"
+        sizes="(max-width: 768px) 50vw, 433px"
         className={styles.ring}
         priority
       />

--- a/app/landingPage/page.module.css
+++ b/app/landingPage/page.module.css
@@ -42,12 +42,13 @@
   display: flex;
   flex-direction: column;
   align-items: center; 
-  justify-content: space-between; 
+  justify-content: flex-start; 
   width: 100%;
   text-align: center;
   color: #ffffff;
   padding-top: clamp(48px, 12vw, 120px); /* responsive vertical start */
   text-align: center;
+  overflow: hidden;
 }
 
 .eyebrow {
@@ -105,11 +106,15 @@
 
 
  .ring {
-    width: 433px;
+    width: clamp(250px, 60vw, 433px);
     height: auto;
   }
   .ringAbsoluteWrapper {
     margin-top: clamp(10px, 10vw, 130px); 
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
   .beautifulTextOuterWrapper{
     margin: 0 auto;
@@ -141,6 +146,72 @@
       text-align: left;
       font-size: 32px;
       line-height: 1.2;
+    }
+    
+    /* Hero section mobile adjustments */
+    .heroFrame {
+      height: clamp(400px, 60vh, 500px);
+    }
+    
+    .overlay {
+      padding-top: clamp(30px, 8vw, 60px);
+      padding-bottom: 20px;
+    }
+    
+    .eyebrow {
+      font-size: clamp(10px, 2.5vw, 12px);
+    }
+    
+    .title {
+      font-size: clamp(24px, 7vw, 36px);
+      margin: 0 0 clamp(6px, 1.5vw, 12px);
+    }
+    
+    .subtitle {
+      font-size: clamp(12px, 3vw, 14px);
+      margin: 0 0 clamp(12px, 2vw, 20px);
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+    
+    .cta {
+      font-size: 12px;
+      padding: 12px 18px;
+      height: 35px;
+    }
+    
+    .ring {
+      width: clamp(200px, 50vw, 300px);
+      max-width: 90%;
+    }
+    
+    .ringAbsoluteWrapper {
+      margin-top: clamp(20px, 5vw, 40px);
+      position: relative;
+      z-index: 1;
+    }
+  }
+  
+  /* Extra small mobile screens */
+  @media (max-width: 480px) {
+    .heroFrame {
+      height: clamp(350px, 55vh, 450px);
+    }
+    
+    .overlay {
+      padding-top: clamp(20px, 6vw, 40px);
+    }
+    
+    .title {
+      font-size: clamp(20px, 6vw, 28px);
+    }
+    
+    .ring {
+      width: clamp(160px, 45vw, 250px);
+    }
+    
+    .ringAbsoluteWrapper {
+      margin-top: clamp(10px, 3vw, 30px);
     }
   }
   .beautifulText{


### PR DESCRIPTION
Make the landing page's hero section responsive to keep the ring within bounds on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-00796b9c-f37e-42dc-85c3-157f5936ec8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00796b9c-f37e-42dc-85c3-157f5936ec8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make ring parallax movement and sizing responsive and refine hero layout/spacing for mobile and small screens.
> 
> - **Hero/Parallax**:
>   - Make `MAX_PARALLAX_Y_MOVEMENT` responsive in `app/landingPage/ParallaxRing.tsx` (−200 on small screens, −400 otherwise).
>   - Tweak `Image` `sizes` to `(max-width: 768px) 50vw, 433px`.
> - **Styles (app/landingPage/page.module.css)**:
>   - Adjust `.overlay` alignment to `flex-start` and add `overflow: hidden`.
>   - Make `.ring` width responsive and center via updated `.ringAbsoluteWrapper` (full-width flex container).
>   - Add mobile and extra-small breakpoints: tuned heights, paddings, font sizes, CTA dimensions, and ring sizing/margins to keep the ring within bounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6e7a683dd995aa02b1513c2e51a721f1cc0f492. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->