### PR TITLE
Adjust heading top margin to 72px

### DIFF
--- a/app/landingPage/page.module.css
+++ b/app/landingPage/page.module.css
@@ -46,7 +46,7 @@
   width: 100%;
   text-align: center;
   color: #ffffff;
-  padding-top: clamp(48px, 12vw, 120px); /* responsive vertical start */
+  padding-top: 0; /* Removed padding since eyebrow has 72px margin-top */
   text-align: center;
   overflow: hidden;
 }
@@ -58,7 +58,7 @@
     font-size: clamp(11px, 1.3vw, 14px);
     letter-spacing: clamp(0.05em, 0.5vw, 0.2em); 
     text-align: center;
-    margin: 0 0 clamp(6px, 1.2vw, 12px);
+    margin: 72px 0 clamp(6px, 1.2vw, 12px);
 }
 
 .title {
@@ -110,7 +110,7 @@
     height: auto;
   }
   .ringAbsoluteWrapper {
-    margin-top: clamp(10px, 10vw, 130px); 
+    margin-top: clamp(40px, 15vw, 180px); 
     width: 100%;
     display: flex;
     justify-content: center;
@@ -154,12 +154,13 @@
     }
     
     .overlay {
-      padding-top: clamp(30px, 8vw, 60px);
+      padding-top: 0;
       padding-bottom: 20px;
     }
     
     .eyebrow {
       font-size: clamp(10px, 2.5vw, 12px);
+      margin: 40px 0 clamp(6px, 1.2vw, 12px);
     }
     
     .title {
@@ -186,7 +187,7 @@
     }
     
     .ringAbsoluteWrapper {
-      margin-top: clamp(20px, 5vw, 40px);
+      margin-top: clamp(30px, 8vw, 60px);
       position: relative;
       z-index: 1;
     }
@@ -199,7 +200,7 @@
     }
     
     .overlay {
-      padding-top: clamp(20px, 6vw, 40px);
+      padding-top: 0;
     }
     
     .title {
@@ -211,7 +212,7 @@
     }
     
     .ringAbsoluteWrapper {
-      margin-top: clamp(10px, 3vw, 30px);
+      margin-top: clamp(20px, 5vw, 40px);
     }
   }
   .beautifulText{


### PR DESCRIPTION
Adjust heading margin-top to 72px and lower the ring position to fix layout issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-624973ce-3c0a-4f79-a4d2-116a238af9bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-624973ce-3c0a-4f79-a4d2-116a238af9bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines hero layout by removing overlay top padding, adding a 72px eyebrow top margin, and increasing ring top margins across breakpoints.
> 
> - **Frontend CSS (landing hero)** in `app/landingPage/page.module.css`:
>   - **Overlay**: set `padding-top` to `0` (desktop and mobile breakpoints).
>   - **Eyebrow**: add `margin-top: 72px` on desktop; `40px` on mobile.
>   - **Ring position**: increase `.ringAbsoluteWrapper` `margin-top` (desktop and mobile) to lower the ring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9d2a5ebca3312f6f5d86aade5cc17fab88ad7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->