### PR TITLE
Fix mobile ring scroll behavior

### DIFF
--- a/app/landingPage/ParallaxRing.tsx
+++ b/app/landingPage/ParallaxRing.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/dist/ScrollTrigger'; // Import ScrollTrigger for Next.js
 import styles from "./page.module.css";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 // 1. Register plugins once globally (best practice)
 if (typeof window !== 'undefined') {
@@ -13,30 +14,33 @@ if (typeof window !== 'undefined') {
 export default function ParallaxRing() {
   // 2. Create a ref to attach to the element we want to move
   const ringRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const ringElement = ringRef.current;
     if (!ringElement) return;
     
-    // Define the maximum distance (in pixels) the ring should move up
-    const MAX_PARALLAX_Y_MOVEMENT = window.innerWidth <= 768 ? -200 : -400;
+    // Define different movement values for mobile and desktop
+    const MAX_PARALLAX_Y_MOVEMENT = isMobile ? -250 : -400;
+    const START_POSITION = isMobile ? "top bottom" : "top 80%";
+    const END_DISTANCE = isMobile ? "+=600" : "+=1000";
 
     // 3. Set up the GSAP animation linked to the scroll
     // We use .to() to animate from the current state (defined by CSS 'bottom: -150px') 
     // to the destination state (y: -150px)
     gsap.to(ringElement, {
-      // The destination state: move 150 pixels up (negative Y)
+      // The destination state: move up (negative Y)
       y: MAX_PARALLAX_Y_MOVEMENT, 
       ease: "none", // Use linear easing for a direct 1:1 link to scroll speed
       
       scrollTrigger: {
         trigger: ringElement, // The element that defines the scroll bounds
         
-        // Start: When the top of the ring's wrapper hits 80% of the viewport height (near the bottom)
-        start: "top 80%", 
+        // Start: Different start position for mobile
+        start: START_POSITION, 
         
-        // End: The animation completes when the top of the ring's wrapper hits the center of the viewport
-        end: "+=1000",
+        // End: The animation completes after scrolling this distance
+        end: END_DISTANCE,
         
         scrub: true, // IMPORTANT: Links the animation's progress directly to the scrollbar
         // markers: true, // Uncomment for debugging the start/end points
@@ -53,11 +57,11 @@ export default function ParallaxRing() {
         }
       });
     };
-  }, []); // Empty dependency array means it runs only ONCE on mount
+  }, [isMobile]); // Re-run when isMobile changes
 
   return (
     // 5. Attach the ref here
-    <div ref={ringRef} className={styles.ringAbsoluteWrapper}> 
+    <div ref={ringRef} className={isMobile ? styles.ringAbsoluteWrapperMobile : styles.ringAbsoluteWrapper}> 
       <Image
         src="/ring.svg" // Keep the image source as you provided
         alt="Ultrahuman Ring AIR"

--- a/app/landingPage/page.module.css
+++ b/app/landingPage/page.module.css
@@ -19,7 +19,7 @@
   margin-bottom: 32px;
   max-height: 730px;
   width: 100%;
-  
+  position: relative;
 }
 
 .heroFrame {
@@ -116,6 +116,19 @@
     justify-content: center;
     align-items: center;
   }
+  
+  /* Mobile-specific ring wrapper with absolute positioning */
+  .ringAbsoluteWrapperMobile {
+    position: absolute;
+    bottom: -180px; /* Start position - ring mostly below viewport */
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+  }
   .beautifulTextOuterWrapper{
     margin: 0 auto;
     display: flex;
@@ -127,6 +140,10 @@
 
   /* Mobile layout for beautifulTextOuterWrapper */
   @media (max-width: 768px) {
+    .hero {
+      margin-bottom: 150px; /* Extra space for ring */
+    }
+    
     .beautifulTextOuterWrapper {
       flex-direction: column;
       align-items: flex-start;
@@ -151,11 +168,15 @@
     /* Hero section mobile adjustments */
     .heroFrame {
       height: clamp(400px, 60vh, 500px);
+      position: relative;
+      overflow: visible; /* Allow ring to extend outside */
     }
     
     .overlay {
       padding-top: 0;
       padding-bottom: 20px;
+      position: relative;
+      overflow: visible; /* Allow ring to extend outside */
     }
     
     .eyebrow {
@@ -182,14 +203,19 @@
     }
     
     .ring {
-      width: clamp(200px, 50vw, 300px);
+      width: clamp(250px, 70vw, 300px);
+      height: auto;
       max-width: 90%;
     }
     
+    /* Hide desktop ring wrapper on mobile */
     .ringAbsoluteWrapper {
-      margin-top: clamp(30px, 8vw, 60px);
-      position: relative;
-      z-index: 1;
+      display: none;
+    }
+    
+    /* Show mobile ring wrapper */
+    .ringAbsoluteWrapperMobile {
+      display: flex;
     }
   }
   

--- a/app/landingPage/page.tsx
+++ b/app/landingPage/page.tsx
@@ -76,8 +76,9 @@ export default function LandingPage() {
               <Link href="/buyRing" className={styles.cta}>
                 Buy Now
               </Link>
-              <ParallaxRing />
+              {!isMobile && <ParallaxRing />}
             </div>
+            {isMobile && <ParallaxRing />}
           </div>    
         </section>
 


### PR DESCRIPTION
Fix mobile view of ParallaxRing component to correctly position the ring at the bottom and animate it upwards on scroll.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b36415e-6f17-4bd2-9b66-bda8c006a1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b36415e-6f17-4bd2-9b66-bda8c006a1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make ParallaxRing responsive by adding mobile-specific GSAP scroll settings and absolute positioning, with conditional rendering and supporting CSS updates.
> 
> - **Landing Page**:
>   - **`ParallaxRing.tsx`**:
>     - Add `useIsMobile` to drive responsive behavior.
>     - Use mobile-specific GSAP `ScrollTrigger` values (`start`, `end`, `y`) and re-run effect on `isMobile` changes.
>     - Switch wrapper class to `ringAbsoluteWrapperMobile` on mobile.
>   - **`page.tsx`**:
>     - Conditionally render `ParallaxRing` inside hero for desktop and outside for mobile.
>   - **`page.module.css`**:
>     - Add `.ringAbsoluteWrapperMobile` with absolute bottom positioning and higher `z-index`.
>     - Adjust `.hero`, `.heroFrame`, `.overlay` to be positioned relative and allow overflow for mobile.
>     - Tweak mobile ring sizing and toggle visibility of desktop/mobile wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514e0519e52b9433bf29104b04b544a5e5f939a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->