### PR TITLE
Adjust ring image display for mobile view

### DIFF
--- a/app/landingPage/ParallaxRing.tsx
+++ b/app/landingPage/ParallaxRing.tsx
@@ -21,9 +21,9 @@ export default function ParallaxRing() {
     if (!ringElement) return;
     
     // Define different movement values for mobile and desktop
-    const MAX_PARALLAX_Y_MOVEMENT = isMobile ? -250 : -400;
+    const MAX_PARALLAX_Y_MOVEMENT = isMobile ? -200 : -400;
     const START_POSITION = isMobile ? "top bottom" : "top 80%";
-    const END_DISTANCE = isMobile ? "+=600" : "+=1000";
+    const END_DISTANCE = isMobile ? "+=500" : "+=1000";
 
     // 3. Set up the GSAP animation linked to the scroll
     // We use .to() to animate from the current state (defined by CSS 'bottom: -150px') 

--- a/app/landingPage/page.module.css
+++ b/app/landingPage/page.module.css
@@ -120,7 +120,7 @@
   /* Mobile-specific ring wrapper with absolute positioning */
   .ringAbsoluteWrapperMobile {
     position: absolute;
-    bottom: -180px; /* Start position - ring mostly below viewport */
+    bottom: -250px; /* Start position - only top portion visible matching Figma */
     left: 50%;
     transform: translateX(-50%);
     width: 100%;
@@ -141,7 +141,7 @@
   /* Mobile layout for beautifulTextOuterWrapper */
   @media (max-width: 768px) {
     .hero {
-      margin-bottom: 150px; /* Extra space for ring */
+      margin-bottom: 100px; /* Adjusted space for new ring position */
     }
     
     .beautifulTextOuterWrapper {
@@ -169,14 +169,14 @@
     .heroFrame {
       height: clamp(400px, 60vh, 500px);
       position: relative;
-      overflow: visible; /* Allow ring to extend outside */
+      overflow: hidden; /* Hide ring parts outside the frame */
     }
     
     .overlay {
       padding-top: 0;
       padding-bottom: 20px;
       position: relative;
-      overflow: visible; /* Allow ring to extend outside */
+      overflow: visible; /* Allow ring to extend outside overlay but contained by heroFrame */
     }
     
     .eyebrow {


### PR DESCRIPTION
Hide the bottom portion of the hero ring image and adjust its initial mobile position to match the Figma design.

The `heroFrame` had `overflow: visible`, causing the ring to extend below the hero section background on mobile. By setting `overflow: hidden` and adjusting the ring's `bottom` position, only the top part of the ring is now visible at the starting point, as per the design. Parallax animation values and hero section margin were also updated to accommodate these changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-34d9843b-4540-4fe0-817a-3022d161b43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34d9843b-4540-4fe0-817a-3022d161b43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

